### PR TITLE
Introduce option which allows to skip ISPN container configuration

### DIFF
--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/DatagridDestructor.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/DatagridDestructor.java
@@ -42,6 +42,10 @@ public class DatagridDestructor
    @SuppressWarnings("unchecked")
    public void destroyInfinispanDatagrid(@Observes After event)
    {
+      if (infinispanContext.get() == null) {
+         return;
+      }
+      
       DatagridManager manager = (DatagridManager) infinispanContext.get().get(DatagridManager.class);
       if (manager != null)
       {

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanConfigurator.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanConfigurator.java
@@ -18,6 +18,8 @@
  */
 package org.infinispan.arquillian.core;
 
+import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.container.spi.event.SetupContainer;
 import org.jboss.arquillian.container.spi.event.StartContainer;
@@ -59,6 +61,7 @@ import org.jboss.as.arquillian.container.CommonContainerConfiguration;
 public class InfinispanConfigurator
 {
    private final String STANDALONE_FLAG = "protocol";  //protocol=hotrod|memcached|websocket
+   private final String SKIP_ISPN_CONTEXT_FLAG = "skipIspnContext";  //if the flag is present, container creation and in injection to context is skipped
 
    @Inject
    @SuiteScoped
@@ -72,6 +75,10 @@ public class InfinispanConfigurator
    public void configureInfinispan(@Observes SetupContainer event)
    {
       ContainerDef def = event.getContainer().getContainerConfiguration();
+      Map<String, String> props = def.getContainerProperties();
+      if (props != null && props.containsKey(SKIP_ISPN_CONTEXT_FLAG)) {
+         return;
+      }
 
       if (infinispanContext.get() == null)
       {
@@ -120,7 +127,9 @@ public class InfinispanConfigurator
     */
    public void reconfigureInfinispan(@Observes StartContainer event)
    {
-      AbstractRemoteInfinispanServer server = (AbstractRemoteInfinispanServer) infinispanContext.get().get(RemoteInfinispanServer.class, event.getContainer().getContainerConfiguration().getContainerName());
-      server.invalidateMBeanProvider();
+      if (infinispanContext.get() != null) {
+         AbstractRemoteInfinispanServer server = (AbstractRemoteInfinispanServer) infinispanContext.get().get(RemoteInfinispanServer.class, event.getContainer().getContainerConfiguration().getContainerName());
+         server.invalidateMBeanProvider();
+      }
    }
 }

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,14 @@ Features supporting testing of the embedded mode include:
     - get a transaction manager and other objects belonging to any cache in the cluster 
       (objects like transaction, advanced cache, lock manager, replication listener, etc.)
 
+Usage of container not fully managed by Arquillian:
+
+Some containers, like e.g. EAP 5 container, are not fully managed by Arquillian and need to be stared/stopped manually.
+In such case dependency injection provided by this container cannot be used and you have to create appropriate resource 
+yourselves in the code. If the used Arquillian container is not compatible with one for JBoss AS 7, you also need to
+configure the container to skip adding it to  Infinispan-Arquillian context by setting `<property name="skipIspnContext"/>`
+in Arquillian configuration file.
+
 ##Building
 
    mvn clean install


### PR DESCRIPTION
When tests are run against e.g. EAP5, tests fail because of class cast exception,
aborting all tests.This option allows to configure container so that creation
of ISPN config and adding to context is skipped.
