### PR TITLE
Domain mode support

### DIFF
--- a/examples/infinispan-server/pom.xml
+++ b/examples/infinispan-server/pom.xml
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     <parent>
         <groupId>org.infinispan.arquillian.container</groupId>
         <artifactId>infinispan-parent-arquillian</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -47,9 +47,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>${version.wildfly}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/infinispan-impl/pom.xml
+++ b/infinispan-impl/pom.xml
@@ -85,10 +85,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-common</artifactId>
-            <version>${version.wildfly}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -108,12 +106,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
             <groupId>org.jboss.jbossts</groupId>
             <artifactId>jbossjta</artifactId>
             <version>${version.jbossjta}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-controller-client</artifactId>
-            <version>${version.wildfly}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.remoting3</groupId>

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanResource.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanResource.java
@@ -83,9 +83,36 @@ import java.lang.annotation.Target;
 public @interface InfinispanResource
 {
    /**
-    * Defines container information about which should be injected.
+    * The name of the container.
+    *
+    * For standalone mode, this is the value of the qualifier attribute on container element in arquillian.xml:
+    *
+    *    <container qualifier="value" ... />
+    *
+    * For domain mode, the format should be host:server (e.g. master:server-one)
     * 
     * @return the name of the container
     */
    String value() default "default";
+
+   /**
+    * The host address.
+    *
+    * @return the host address
+    */
+   String host() default "127.0.0.1";
+
+   /**
+    * The jmx port of the server.
+    *
+    * @return jmx port of the server
+    */
+   int jmxPort() default 9990;
+
+   /**
+    * Infinispan JMX domain.
+    *
+    * @return Infinispan JMX domain.
+    */
+   String jmxDomain() default "jboss.datagrid-infinispan";
 }

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanTestEnricher.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/InfinispanTestEnricher.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.spi.Validate;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
-import org.infinispan.arquillian.core.SecurityActions;
 
 /**
  * InfinispanTestEnricher enriches tests with {@link RemoteInfinispanServer} or
@@ -106,9 +105,13 @@ public class InfinispanTestEnricher implements TestEnricher
       }
       else
       {
-         //infinispan context should be created and populated with data from arquillian.xml by now
          Validate.notNull(infinispanContext.get(), "Infinispan context should not be null");
          value = infinispanContext.get().get(type, resource.value());
+         if (value == null) {
+            //this is domain mode, the container is created on demand
+            value = new RemoteInfinispanServerImpl(resource.host(), resource.jmxPort(), true, resource.jmxDomain());
+            infinispanContext.get().add(type, value);
+         }
       }
       return value;
    }

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/RemoteInfinispanServerImpl.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/RemoteInfinispanServerImpl.java
@@ -33,18 +33,18 @@ import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
  *
  */
-public class InfinispanServer extends AbstractRemoteInfinispanServer
+public class RemoteInfinispanServerImpl extends AbstractRemoteInfinispanServer
 {
    private MBeanObjectsProvider mBeans;
-
    private String managementAddress;
-
    private int managementPort;
+   private boolean isDomainMode;
 
-   public InfinispanServer(String managementAddress, int managementPort, String jmxDomain)
+   public RemoteInfinispanServerImpl(String managementAddress, int managementPort, boolean isDomainMode, String jmxDomain)
    {
       this.managementAddress = managementAddress;
       this.managementPort = managementPort;
+      this.isDomainMode = isDomainMode;
       this.provider = createOrGetProvider();
       this.mBeans = new MBeanObjectsProvider(jmxDomain);
    }
@@ -54,7 +54,7 @@ public class InfinispanServer extends AbstractRemoteInfinispanServer
    {
       if (provider == null)
       {
-         provider = new MBeanServerConnectionProvider(managementAddress, managementPort);
+         provider = new MBeanServerConnectionProvider(managementAddress, managementPort, isDomainMode == true ? "remote" : "http-remoting-jmx");
       }
       return provider;
    }
@@ -78,7 +78,8 @@ public class InfinispanServer extends AbstractRemoteInfinispanServer
    }
 
    @Override
-   public HotRodEndpoint getHotrodEndpoint(String name) {
+   public HotRodEndpoint getHotrodEndpoint(String name)
+   {
       return new HotRodEndpoint(name, createOrGetProvider(), mBeans);
    }
 
@@ -89,7 +90,8 @@ public class InfinispanServer extends AbstractRemoteInfinispanServer
    }
 
    @Override
-   public MemCachedEndpoint getMemcachedEndpoint(String name) {
+   public MemCachedEndpoint getMemcachedEndpoint(String name)
+   {
       return new MemCachedEndpoint(name, createOrGetProvider(), mBeans);
    }
 
@@ -97,15 +99,5 @@ public class InfinispanServer extends AbstractRemoteInfinispanServer
    public RESTEndpoint getRESTEndpoint()
    {
       return new RESTEndpoint(createOrGetProvider(), mBeans);
-   }
-
-   void setManagementAddress(String managementAddress)
-   {
-      this.managementAddress = managementAddress;
-   }
-
-   void setManagementPort(int managementPort)
-   {
-      this.managementPort = managementPort;
    }
 }

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/utils/MBeanServerConnectionProvider.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/utils/MBeanServerConnectionProvider.java
@@ -48,14 +48,19 @@ public final class MBeanServerConnectionProvider
 
    public MBeanServerConnectionProvider(String hostAddr, int port)
    {
-      setUpJmxServiceUrl(hostAddr, port);
+      setUpJmxServiceUrl(hostAddr, port, "http-remoting-jmx");
    }
 
-   private void setUpJmxServiceUrl(String hostAddr, int port)
+   public MBeanServerConnectionProvider(String hostAddr, int port, String remotingProtocol)
+   {
+      setUpJmxServiceUrl(hostAddr, port, remotingProtocol);
+   }
+
+   private void setUpJmxServiceUrl(String hostAddr, int port, String remotingProtocol)
    {
       this.hostAddr = hostAddr;
       this.port = port;
-      this.jmxServiceUrl = getRemotingJmxUrl();
+      this.jmxServiceUrl = getRemotingJmxUrl(remotingProtocol);
    }
 
    public MBeanServerConnection getConnection()
@@ -77,7 +82,7 @@ public final class MBeanServerConnectionProvider
       }
    }
 
-   private String getRemotingJmxUrl()
+   private String getRemotingJmxUrl(String jmxProtocol)
    {
       String useHostAddr = hostAddr;
       if (isValidInet6Address(hostAddr) && !hostAddr.matches(IPV6_BRACKETS_REGEX))
@@ -85,18 +90,6 @@ public final class MBeanServerConnectionProvider
          // add brackets if NO brackets specified
          useHostAddr = "[" + hostAddr + "]";
       }
-
-      if (String.valueOf(port).endsWith("9"))
-      {
-         // old jboss-as management port: remoting-jmx
-         log.info("Management port " + port + " ends with \"9\" -- " +
-                 "remoting-jmx protocol for JBoss AS is used instead of http-remoting-jmx for Wildfly.");
-         return "service:jmx:remoting-jmx://" + useHostAddr + ":" + port;
-      }
-      else
-      {
-         // wildfly: http-remoting-jmx
-         return "service:jmx:http-remoting-jmx://" + useHostAddr + ":" + port;
-      }
+      return "service:jmx:" + jmxProtocol + "://" + useHostAddr + ":" + port;
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     <!-- Properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        
-        <version.wildfly>8.1.0.CR2</version.wildfly>
-        <version.arquillian_core>1.0.3.Final</version.arquillian_core>
+
+        <version.org.wildfly.core>2.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
+        <version.arquillian_core>1.1.10.Final</version.arquillian_core>
         <version.infinispan_core>7.0.0.Alpha4</version.infinispan_core>
         <version.infinispan_core_tests>${version.infinispan_core}</version.infinispan_core_tests>
         <version.hotrod.client>${version.infinispan_core}</version.hotrod.client>
@@ -137,6 +138,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
                 <artifactId>infinispan-core</artifactId>
                 <version>${version.infinispan_core}</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-common</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-managed</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>


### PR DESCRIPTION
These changes are required so that infinispan-arquillian works with ISPN servers started in domain mode. The main difference is different jmx port and protocol.