### PR TITLE
Add NumberOfEntriesInMemory stat.

### DIFF
--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/model/CacheStatistics.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/model/CacheStatistics.java
@@ -30,6 +30,7 @@ public enum CacheStatistics
    EVICTIONS("Evictions"), REMOVE_MISSES("RemoveMisses"),
    READ_WRITE_RATIO("ReadWriteRatio"), HITS("Hits"),
    NUMBER_OF_ENTRIES("NumberOfEntries"),
+   NUMBER_OF_ENTRIES_IN_MEMORY("NumberOfEntriesInMemory"),
    TIME_SINCE_RESET("TimeSinceReset"),
    ELAPSED_TIME("ElapsedTime"),
    MISSES("Misses"),
@@ -41,7 +42,7 @@ public enum CacheStatistics
 
    private String statsValue;
 
-   private CacheStatistics(String locStatsValue)
+   CacheStatistics(String locStatsValue)
    {
       this.statsValue = locStatsValue;
    }

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/model/RemoteInfinispanCache.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/model/RemoteInfinispanCache.java
@@ -203,6 +203,17 @@ public class RemoteInfinispanCache
    {
       return Long.parseLong(getStatistics(CacheStatistics.NUMBER_OF_ENTRIES));
    }
+
+   /**
+    *
+    * Returns a number of entries currently stored in-memory in the cache.
+    *
+    * @return the number of entries currently in-memory  the cache
+    */
+   public long getNumberOfEntriesInMemory()
+   {
+      return Long.parseLong(getStatistics(CacheStatistics.NUMBER_OF_ENTRIES_IN_MEMORY));
+   }
    
    /**
     * 


### PR DESCRIPTION
This is necessary to fix some test failures in Infinispan that were introduced due to the NumberOfEntries stat now excluding expired entries and including passivated ones. 