### PR TITLE
[GH-39] Rest endpoint should use rest mbean

### DIFF
--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/core/RESTEndpoint.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/core/RESTEndpoint.java
@@ -57,12 +57,12 @@ public class RESTEndpoint
       String hostname;
       try
       {
-         hostname = MBeanUtils.getMBeanAttribute(provider, mBeans.getHorRodServerMBean(), ServerModuleAttributes.HOST_NAME);
+         hostname = MBeanUtils.getMBeanAttribute(provider, mBeans.getRestServerMBean(), ServerModuleAttributes.HOST_NAME);
          return InetAddress.getByName(hostname);
       }
       catch (Exception e)
       {
-         throw new RuntimeException("Could not retrieve HotRod host", e);
+         throw new RuntimeException("Could not retrieve REST host", e);
       }
    }
 

--- a/infinispan-impl/src/main/java/org/infinispan/arquillian/utils/MBeanObjectsProvider.java
+++ b/infinispan-impl/src/main/java/org/infinispan/arquillian/utils/MBeanObjectsProvider.java
@@ -128,6 +128,29 @@ public class MBeanObjectsProvider
 
    /**
     *
+    * Returns a REST server MBean.
+    *
+    * @param endpointName the name of the endpoint as specified in the server's configuration file
+    * @return the REST server MBean
+    */
+   public String getRestServerMBean(String endpointName)
+   {
+      return domain + ":type=Server,name=REST" + getEndpointSuffix(endpointName) + ",component=Transport";
+   }
+
+   /**
+    *
+    * Returns a REST server MBean with a default name.
+    *
+    * @return the REST server MBean
+    */
+   public String getRestServerMBean()
+   {
+      return getRestServerMBean("");
+   }
+
+   /**
+    *
     * Returns a HotRod server MBean.
     *
     * @param endpointName the name of the endpoint as specified in the server's configuration file


### PR DESCRIPTION
https://github.com/infinispan/infinispan-arquillian-container/issues/39

When clients communicates with server only via REST, HR server
need'nt to be defined at all. Therefore REST endpoint should use
only REST mbeans and not rely on HR mbeans.